### PR TITLE
cygwin uses SHA512 instead of MD5

### DIFF
--- a/apt-cyg
+++ b/apt-cyg
@@ -424,12 +424,12 @@ case "$command" in
     cd "release/$pkg"
     wget -nc $mirror/$install
 
-    # check the md5
+    # check the SHA512 sum
     digest=`cat "desc" | awk '/^install: / { print $4; exit }'`
-    digactual=`md5sum $file | awk '{print $1}'`
+    digactual=`sha512sum $file | awk '{print $1}'`
     if ! test $digest = $digactual
     then
-      echo MD5 sum did not match, exiting
+      echo SHA512 sum did not match, exiting
       exit 1
     fi
 


### PR DESCRIPTION
http://superuser.com/questions/894696/apt-cyg-install-return-md5sum-error
